### PR TITLE
Remove trailing comma for php <=7.2 compatibility

### DIFF
--- a/src/AI_Command.php
+++ b/src/AI_Command.php
@@ -343,7 +343,7 @@ class AI_Command extends WP_CLI_Command {
 				// @phpstan-ignore class.notFound
 				$token_usage[ TokenUsage::KEY_COMPLETION_TOKENS ],
 				// @phpstan-ignore class.notFound
-				$token_usage[ TokenUsage::KEY_TOTAL_TOKENS ],
+				$token_usage[ TokenUsage::KEY_TOTAL_TOKENS ]
 			),
 			'ai'
 		);


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli-bundle/pull/952