### PR TITLE
Fix incorrect `--output` argument in generate image example

### DIFF
--- a/src/AI_Command.php
+++ b/src/AI_Command.php
@@ -110,7 +110,7 @@ class AI_Command extends WP_CLI_Command {
 	 *     $ wp ai generate text "Explain AI" --system-instruction="Explain as if to a 5-year-old"
 	 *
 	 *     # Generate image
-	 *     $ wp ai generate image "A minimalist WordPress logo" --output=wp-logo.png
+	 *     $ wp ai generate image "A minimalist WordPress logo" --destination-file=wp-logo.png
 	 *
 	 * @param array{0: string, 1: string} $args Positional arguments.
 	 * @param array{model: string, provider: string, temperature: float, 'top-p': float, 'top-k': int, 'max-tokens': int, 'system-instruction': string, 'destination-file': string, stdout: bool, format: string} $assoc_args Associative arguments.


### PR DESCRIPTION
Closes https://github.com/wp-cli/ai-command/issues/18

The inline example used `--output` which is not a registered argument. The correct argument is `--destination-file`.

```diff
- $ wp ai generate image "A minimalist WordPress logo" --output=wp-logo.png
+ $ wp ai generate image "A minimalist WordPress logo" --destination-file=wp-logo.png
```
